### PR TITLE
FEAT: MON-28: create mp endpoints

### DIFF
--- a/app/api/mp/create-preference/route.js
+++ b/app/api/mp/create-preference/route.js
@@ -1,3 +1,4 @@
+import { APP_SCHEMA, BACK_URL } from "@/app/constants";
 import { MercadoPagoConfig, Preference } from "mercadopago";
 
 const mercadoPago = new MercadoPagoConfig({
@@ -21,10 +22,16 @@ export const preferenceBuilder = (preferenceDraft) => {
       },
       operation_type: "regular_payment",
       back_urls: {
-        success: process.env.APP_HOST_URL,
-        failure: process.env.APP_HOST_URL,
-        pending: process.env.APP_HOST_URL,
+        success: `${APP_SCHEMA}://${BACK_URL.SUCCESS}`,
+        failure: `${APP_SCHEMA}://${BACK_URL.FAILURE}`,
+        pending: `${APP_SCHEMA}://${BACK_URL.PENDING}`,
       },
+      redirect_urls: {
+        failure: `${APP_SCHEMA}://${BACK_URL.FAILURE}`,
+        pending: `${APP_SCHEMA}://${BACK_URL.PENDING}`,
+        success: `${APP_SCHEMA}://${BACK_URL.SUCCESS}`,
+      },
+      auto_return: "approved",
       notificationUrl: `${process.env.APP_HOST_URL}/api/mp/payment-data`,
     },
   };
@@ -43,7 +50,6 @@ export const POST = async (request) => {
       headers: { "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.log(`Error: ${error}`);
     throw error;
   }
 };

--- a/app/api/mp/create-preference/route.js
+++ b/app/api/mp/create-preference/route.js
@@ -1,0 +1,49 @@
+import { MercadoPagoConfig, Preference } from "mercadopago";
+
+const mercadoPago = new MercadoPagoConfig({
+  accessToken: process.env.MP_ACCESS_TOKEN,
+});
+
+export const preferenceBuilder = (preferenceDraft) => {
+  return {
+    body: {
+      items: [
+        {
+          id: preferenceDraft.giftId,
+          unit_price: preferenceDraft.amount,
+          quantity: 1,
+          title: preferenceDraft.productName,
+        },
+      ],
+      metadata: {
+        message: preferenceDraft?.message,
+        user_id: preferenceDraft.userId,
+      },
+      operation_type: "regular_payment",
+      back_urls: {
+        success: process.env.APP_HOST_URL,
+        failure: process.env.APP_HOST_URL,
+        pending: process.env.APP_HOST_URL,
+      },
+      notificationUrl: `${process.env.APP_HOST_URL}/api/mp/payment-data`,
+    },
+  };
+};
+
+export const POST = async (request) => {
+  const preferenceDraft = await request.json();
+
+  try {
+    const preferenceData = preferenceBuilder(preferenceDraft);
+
+    const preference = await new Preference(mercadoPago).create(preferenceData);
+
+    return new Response(JSON.stringify(preference, null, 2), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.log(`Error: ${error}`);
+    throw error;
+  }
+};

--- a/app/api/mp/payment-data/route.js
+++ b/app/api/mp/payment-data/route.js
@@ -5,10 +5,12 @@ const client = new MercadoPagoConfig({
 });
 
 const getPaymentInfo = (payment) => {
-  const { id, unit_price, currency_id, metadata, date_created } = payment;
+  const { payer, additional_info, currency_id, metadata, date_created } =
+    payment;
+  const { id: gift_id, unit_price } = additional_info.items[0];
   return {
-    id: "",
-    gift_id: id,
+    id: payer.id,
+    gift_id,
     user_id: metadata.user_id,
     amount: unit_price,
     currency: currency_id,
@@ -25,12 +27,13 @@ export const POST = async (request) => {
 
     // TODO: create call to database
 
-    return new Response(JSON.stringify(paymentInfo, 2, null), {
+    return new Response(JSON.stringify({ success: true }), {
       status: 200,
-      headers: { "Content-Type": "application/json" },
     });
   } catch (error) {
     console.log(`Error: ${error}`);
-    throw error;
+    return new Response(JSON.stringify({ success: false }), {
+      status: 500,
+    });
   }
 };

--- a/app/api/mp/payment-data/route.js
+++ b/app/api/mp/payment-data/route.js
@@ -1,0 +1,36 @@
+import { MercadoPagoConfig, Payment } from "mercadopago";
+
+const client = new MercadoPagoConfig({
+  accessToken: process.env.MP_ACCESS_TOKEN,
+});
+
+const getPaymentInfo = (payment) => {
+  const { id, unit_price, currency_id, metadata, date_created } = payment;
+  return {
+    id: "",
+    gift_id: id,
+    user_id: metadata.user_id,
+    amount: unit_price,
+    currency: currency_id,
+    created_at: date_created,
+  };
+};
+
+export const POST = async (request) => {
+  try {
+    const body = await request.json().then((data) => data);
+    const payment = await new Payment(client).get({ id: body.data.id });
+
+    const paymentInfo = getPaymentInfo(payment);
+
+    // TODO: create call to database
+
+    return new Response(JSON.stringify(paymentInfo, 2, null), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.log(`Error: ${error}`);
+    throw error;
+  }
+};

--- a/app/constants.js
+++ b/app/constants.js
@@ -1,1 +1,7 @@
+export const BACK_URL = {
+  SUCCESS: "success",
+  FAILURE: "failure",
+  PENDING: "pending",
+};
 
+export const APP_SCHEMA = "acme";


### PR DESCRIPTION
Created two endpoints:
   - api/mp/create-preference: this endpoint must create the preference that expo bow-fe will consume
```
{
   "amount": 1, 
   "giftId": "2", 
   "productName": "Nike Shoes", 
   "userId": "123", 
   "message": "message" 
}
```
---

   - api/mp/payment-data: this endpoint should be called after the payment is created from the web navigator on expo bow-fe and must get the payment info to store it in the database.
```
{
   "id": 2,
   "metadata": {
    "user_id": "John Doe"
   },
   "unit_price": "500",
   "currency_id": "ARS",
   "date_created": "7/11/2024"
}
```


Linear ticket: [MON-28](https://linear.app/monoisla/issue/MON-28/integrate-mercadopago)
